### PR TITLE
Update log_date_format type

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,7 +268,7 @@ The available attributes try to represent the PM2 json definition options [schem
         <td>No</td>
     </tr>
     <tr>
-        <td><tt>log_data_format</tt></td>
+        <td><tt>log_date_format</tt></td>
         <td>String</td>
         <td>See PM2 documentation for reference</td>
         <td>No</td>


### PR DESCRIPTION
Original README has a typo that for the 'log_date_format' that reads 'log_data_format'.